### PR TITLE
Reduce production size

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "prettier": "^1.12.1",
     "rimraf": "^2.6.2",
     "rollup": "^0.64.1",
-    "rollup-plugin-babel": "^3.0.7"
+    "rollup-plugin-babel": "^3.0.7",
+    "rollup-plugin-replace": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,18 @@
 {
   "name": "tiny-invariant",
   "version": "0.0.3",
-  "keywords": ["invariant", "error"],
+  "keywords": [
+    "invariant",
+    "error"
+  ],
   "description": "A tiny invariant function",
   "main": "dist/tiny-invariant.cjs.js",
   "module": "dist/tiny-invariant.esm.js",
   "sideEffects": false,
-  "files": ["/dist", "/src"],
+  "files": [
+    "/dist",
+    "/src"
+  ],
   "author": "Alex Reardon <alexreardon@gmail.com>",
   "license": "MIT",
   "scripts": {
@@ -15,8 +21,7 @@
     "typecheck": "yarn flow",
     "validate": "yarn lint && yarn flow",
     "build:clean": "rimraf dist",
-    "build:flow":
-      "echo \"// @flow\n\nexport * from '../src';\" > dist/tiny-invariant.cjs.js.flow",
+    "build:flow": "echo \"// @flow\n\nexport * from '../src';\" > dist/tiny-invariant.cjs.js.flow",
     "build:dist": "yarn rollup --config rollup.config.js",
     "build": "yarn build:clean && yarn build:dist && yarn build:flow",
     "prepublishOnly": "yarn build"
@@ -31,7 +36,7 @@
     "jest": "^22.4.3",
     "prettier": "^1.12.1",
     "rimraf": "^2.6.2",
-    "rollup": "^0.58.0",
-    "rollup-plugin-babel": "^3.0.3"
+    "rollup": "^0.64.1",
+    "rollup-plugin-babel": "^3.0.7"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,5 @@
 import babel from 'rollup-plugin-babel';
+import pkg from './package.json';
 
 const input = 'src/index.js';
 
@@ -7,8 +8,8 @@ export default [
   {
     input,
     output: {
-      file: 'dist/tiny-invariant.esm.js',
-      format: 'es',
+      file: pkg.module,
+      format: 'esm',
     },
     plugins: [babel()],
   },
@@ -16,7 +17,7 @@ export default [
   {
     input,
     output: {
-      file: 'dist/tiny-invariant.cjs.js',
+      file: pkg.main,
       format: 'cjs',
     },
     plugins: [babel()],

--- a/src/index.js
+++ b/src/index.js
@@ -12,11 +12,13 @@ export default (condition: mixed, message?: string) => {
 
   // Condition not passed
 
-  // In production we strip the message but still throw
   if (isProduction) {
+    // In production we strip the message but still throw
     throw new Error(prefix);
   }
 
-  // In other environments we throw with the message
-  throw new Error(`${prefix}: ${message || ''}`);
+  if (!isProduction) {
+    // In other environments we throw with the message
+    throw new Error(`${prefix}: ${message || ''}`);
+  }
 };

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -4,8 +4,8 @@ import { rollup } from 'rollup';
 import babel from 'rollup-plugin-babel';
 import replace from 'rollup-plugin-replace';
 
-const DEV_SIZE = 414;
-const PROD_SIZE = 535;
+const DEV_SIZE = 426;
+const PROD_SIZE = 431;
 
 const getSizeInMode = async ({ mode }) => {
   const bundle = await rollup({

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,5 +1,29 @@
 // @flow
 import invariant from '../src';
+import { rollup } from 'rollup';
+import babel from 'rollup-plugin-babel';
+import replace from 'rollup-plugin-replace';
+
+const DEV_SIZE = 414;
+const PROD_SIZE = 535;
+
+const getSizeInMode = async ({ mode }) => {
+  const bundle = await rollup({
+    input: './src/index.js',
+    output: {
+      format: 'esm',
+    },
+    plugins: [
+      babel({
+        babelrc: false,
+        presets: ['flow', ['env', { modules: false, loose: true }]],
+      }),
+      replace({ 'process.env.NODE_ENV': JSON.stringify(mode) }),
+    ],
+  });
+  const { code } = await bundle.generate({ format: 'esm' });
+  return code.length;
+};
 
 it('should not throw if condition is truthy', () => {
   const truthy: mixed[] = [1, -1, true, {}, [], Symbol(), 'hi'];
@@ -12,4 +36,12 @@ it('should throw if the condition is falsy', () => {
   // https://github.com/getify/You-Dont-Know-JS/blob/master/types%20%26%20grammar/ch4.md#falsy-values
   const falsy: mixed[] = [undefined, null, false, +0, -0, NaN, ''];
   falsy.forEach((value: mixed) => expect(() => invariant(value)).toThrow());
+});
+
+it(`development mode size should be ${DEV_SIZE}`, async () => {
+  expect(await getSizeInMode({ mode: 'development' })).toBe(DEV_SIZE);
+});
+
+it(`production mode size should be ${PROD_SIZE}`, async () => {
+  expect(await getSizeInMode({ mode: 'production' })).toBe(PROD_SIZE);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1234,6 +1234,10 @@ estree-walker@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.2.1.tgz#bdafe8095383d8414d5dc2ecf4c9173b6db9412e"
 
+estree-walker@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.5.2.tgz#d3850be7529c9580d815600b53126515e146dd39"
+
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
@@ -2446,6 +2450,12 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+magic-string@^0.22.4:
+  version "0.22.5"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.22.5.tgz#8e9cf5afddf44385c1da5bc2a6a0dbd10b03657e"
+  dependencies:
+    vlq "^0.2.2"
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -3162,12 +3172,27 @@ rollup-plugin-babel@^3.0.7:
   dependencies:
     rollup-pluginutils "^1.5.0"
 
+rollup-plugin-replace@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-replace/-/rollup-plugin-replace-2.0.0.tgz#19074089c8ed57184b8cc64e967a03d095119277"
+  dependencies:
+    magic-string "^0.22.4"
+    minimatch "^3.0.2"
+    rollup-pluginutils "^2.0.1"
+
 rollup-pluginutils@^1.5.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz#1e156e778f94b7255bfa1b3d0178be8f5c552408"
   dependencies:
     estree-walker "^0.2.1"
     minimatch "^3.0.2"
+
+rollup-pluginutils@^2.0.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.3.1.tgz#760d185ccc237dedc12d7ae48c6bcd127b4892d0"
+  dependencies:
+    estree-walker "^0.5.2"
+    micromatch "^2.3.11"
 
 rollup@^0.64.1:
   version "0.64.1"
@@ -3657,6 +3682,10 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vlq@^0.2.2:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.3.tgz#8f3e4328cf63b1540c0d67e1b2778386f8975b26"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,9 +16,9 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@types/estree@0.0.38":
-  version "0.0.38"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.38.tgz#c1be40aa933723c608820a99a373a16d215a1ca2"
+"@types/estree@0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
 
 "@types/node@*":
   version "9.6.5"
@@ -1400,9 +1400,9 @@ find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
-flow-bin@^0.70.0:
-  version "0.70.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.70.0.tgz#080ae83a997f2b4ddb3dc2649bf13336825292b5"
+flow-bin@^0.71.0:
+  version "0.71.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.71.0.tgz#fd1b27a6458c3ebaa5cb811853182ed631918b70"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -3156,9 +3156,9 @@ rimraf@2, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   dependencies:
     glob "^7.0.5"
 
-rollup-plugin-babel@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-3.0.3.tgz#63adedc863130327512a4a9006efc2241c5b7c15"
+rollup-plugin-babel@^3.0.7:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-3.0.7.tgz#5b13611f1ab8922497e9d15197ae5d8a23fe3b1e"
   dependencies:
     rollup-pluginutils "^1.5.0"
 
@@ -3169,11 +3169,11 @@ rollup-pluginutils@^1.5.0:
     estree-walker "^0.2.1"
     minimatch "^3.0.2"
 
-rollup@^0.58.0:
-  version "0.58.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.58.0.tgz#6a3a51f90916ae703d0dc807a5652799ca0ccfc2"
+rollup@^0.64.1:
+  version "0.64.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.64.1.tgz#9188ee368e5fcd43ffbc00ec414e72eeb5de87ba"
   dependencies:
-    "@types/estree" "0.0.38"
+    "@types/estree" "0.0.39"
     "@types/node" "*"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:


### PR DESCRIPTION
Rollup is able to remove falsy constant conditions so I just moved development version into own condition.

Note: commits are important and show the effect. Would be good to merge them without squash.