### PR TITLE
Allow any type for the condition in Typescript

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,1 +1,1 @@
-export default function invariant(condition: boolean, message?: string): void
+export default function invariant(condition: any, message?: string): void


### PR DESCRIPTION
Hey, it seems that the Flow version allows a `mixed` value whereas the Typescript version enforces a `boolean`. It makes the usage of `tiny-invariant` a little tedious in TypeScript:

```ts
const obj = {}
invariant(obj)           // will complain about `obj` not being a `boolean`
invariant(Boolean(obj))  // wil compile fine but is tedious
```

This PR align both type definitions by using `any` in Typescript.