### PR TITLE
Add typescript assertion

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "scripts": {
     "test": "yarn jest",
-    "lint": "yarn prettier --debug-check src/** test/**",
+    "lint": "yarn prettier --check src/** test/**",
     "typecheck": "yarn flow",
     "validate": "yarn lint && yarn flow",
     "build:clean": "rimraf dist",
@@ -43,7 +43,7 @@
     "babel-jest": "^24.8.0",
     "flow-bin": "^0.102.0",
     "jest": "^24.8.0",
-    "prettier": "^1.18.2",
+    "prettier": "^1.19.1",
     "rimraf": "^2.6.3",
     "rollup": "^1.16.6",
     "rollup-plugin-babel": "^4.3.3",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,1 +1,1 @@
-export default function invariant(condition: any, message?: string): void
+export default function invariant(condition: any, message?: string): asserts condition

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,1 +1,4 @@
-export default function invariant(condition: any, message?: string): asserts condition
+export default function invariant(
+  condition: any,
+  message?: string,
+): asserts condition;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3364,10 +3364,10 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
 
-prettier@^1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
-  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+prettier@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-format@^24.8.0:
   version "24.8.0"


### PR DESCRIPTION
With the coming TypeScript 3.7 release in November, there will be a new feature supporting assertions. See https://github.com/microsoft/TypeScript/pull/32695 for more.

This PR works already when using the released 3.7 beta. TypeScript =< 3.6 does not understand this feature, unfortunately.