### PR TITLE
feat: for platforms supporting conditional exports, when importing tiny-invariant from an ESM module, serve an ESM build

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "types": "dist/tiny-invariant.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/node16/tiny-invariant.js",
+      "import": "./dist/esm/tiny-invariant.js",
       "default": "./dist/tiny-invariant.cjs.js"
     }
   },
@@ -60,10 +60,10 @@
     "build:clean": "rimraf dist",
     "build:flow": "cp src/tiny-invariant.js.flow dist/tiny-invariant.cjs.js.flow",
     "build:typescript": "tsc ./src/tiny-invariant.ts --emitDeclarationOnly --declaration --outDir ./dist",
-    "build:typescript:node16": "tsc ./src/tiny-invariant.ts --emitDeclarationOnly --declaration --outDir ./dist/node16",
-    "build:copy-esm-packagejson": "cp static/package-esm.json dist/node16/package.json",
+    "build:typescript:esm": "tsc ./src/tiny-invariant.ts --emitDeclarationOnly --declaration --outDir ./dist/esm",
+    "build:copy-esm-packagejson": "cp static/package-esm.json dist/esm/package.json",
     "build:dist": "yarn rollup --config rollup.config.js",
-    "build": "yarn build:clean && yarn build:dist && yarn build:typescript && yarn build:typescript:node16 && yarn build:copy-esm-packagejson",
+    "build": "yarn build:clean && yarn build:dist && yarn build:typescript && yarn build:typescript:esm && yarn build:copy-esm-packagejson",
     "prepublishOnly": "yarn build"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,12 @@
   "main": "dist/tiny-invariant.cjs.js",
   "module": "dist/tiny-invariant.esm.js",
   "types": "dist/tiny-invariant.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/node16/tiny-invariant.js",
+      "default": "./dist/tiny-invariant.cjs.js"
+    }
+  },
   "sideEffects": false,
   "files": [
     "/dist",
@@ -54,8 +60,10 @@
     "build:clean": "rimraf dist",
     "build:flow": "cp src/tiny-invariant.js.flow dist/tiny-invariant.cjs.js.flow",
     "build:typescript": "tsc ./src/tiny-invariant.ts --emitDeclarationOnly --declaration --outDir ./dist",
+    "build:typescript:node16": "tsc ./src/tiny-invariant.ts --emitDeclarationOnly --declaration --outDir ./dist/node16",
+    "build:copy-esm-packagejson": "cp static/package-esm.json dist/node16/package.json",
     "build:dist": "yarn rollup --config rollup.config.js",
-    "build": "yarn build:clean && yarn build:dist && yarn build:typescript",
+    "build": "yarn build:clean && yarn build:dist && yarn build:typescript && yarn build:typescript:node16 && yarn build:copy-esm-packagejson",
     "prepublishOnly": "yarn build"
   },
   "devDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -43,7 +43,7 @@ export default [
   {
     input,
     output: {
-      file: 'dist/node16/tiny-invariant.js',
+      file: 'dist/esm/tiny-invariant.js',
       format: 'esm',
     },
     plugins: [typescript({ module: 'ESNext' })],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -39,6 +39,15 @@ export default [
     },
     plugins: [typescript({ module: 'ESNext' })],
   },
+  // ESM build for "module": "node16" TypeScript projects (https://github.com/alexreardon/tiny-invariant/issues/144)
+  {
+    input,
+    output: {
+      file: 'dist/node16/tiny-invariant.js',
+      format: 'esm',
+    },
+    plugins: [typescript({ module: 'ESNext' })],
+  },
   // CommonJS build
   {
     input,

--- a/static/package-esm.json
+++ b/static/package-esm.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
Fixes #144

## Current Situation

When `tiny-invariant` is imported from an ESM module in Node.js, like this:

```typescript
import invariant from 'tiny-invariant';
```

...the CJS build of `tiny-invariant` is served.

<details>
  <summary>Here's why 👇</summary>
  
  - Node.js will look up `tiny-invariant` in `node_modules` and look into `package.json`.
  - It first looks for the property `exports`, but since this is not present in the currently published version of `tiny-invariant`, it looks at the property `main`. This property refers to `"dist/tiny-invariant.cjs.js"`. From this point on it is clear that this file will get executed.
  - What is unknown at this point, however, is whether the file contains CJS or ESM code. The file extension `.js` is **ambiguous**, it can contain either CJS or ESM code. To know in which module mode Node.js should run this file, it will search for the "closest" `package.json` file and look at the `type` property. There is no `package.json` in the folder `dist`, so it looks one level up, finding `package.json` of tiny-invariant itself. `type` is not set, so Node.js interprets the file as a CJS file.
</details>

## Goal of this Pull Request

This pull requests adds an ESM build which is used by Node.js and any other platform respecting "conditional exports" when importing `tiny-invariant` from an ESM module.  
This fixes #144.

It uses the technique outlined by [2ality.com/2019/10/hybrid-npm-packages.html#variant%3A-avoiding-.mjs](https://2ality.com/2019/10/hybrid-npm-packages.html#variant%3A-avoiding-.mjs), with the only difference that `tiny-invariant` is still CJS by default and ESM by opt-in.  
The same technique is used by [`safe-stable-stringify`](https://github.com/BridgeAR/safe-stable-stringify/tree/main/).

## Risks

This should be **almost** backwards-compatible, because:

- platforms not supporting the `"exports"` field will still work as before,
- and those platforms respecting the `"exports"` field will use the new file **only** if an ESM `import` is used to consume the package. And then, it will get the same JS as it would have before when it consumed `dist/tiny-invariant.esm.js`.

<details>
  <summary>There's one catch though I am aware of: Reaching into `dist` might not be possible anymore 👇</summary>
  
  `exports` is now defined as:

  ```json
  "exports": {
    ".": {
      "import": "./dist/esm/tiny-invariant.js",
      "default": "./dist/tiny-invariant.cjs.js"
    }
  },
  ```

  Once the property `exports` is present in `package.json`, platforms respecting that property will **refuse** to import anything not specified in `exports`.  
  Thus if some codebase reaches into `dist` like this (**and** the platform respects `exports`):

  ```ts
  import invariant from 'tiny-invariant/dist/tiny-invariant.min.js';
  ```

  ...this will not work anymore.

  We could adapt `exports` such that everything from `dist` is exported, but I wonder if we should do that.  
  This potential problem can affect only modern codebases respecting `exports`, and I would expect that almost everyone is importing `tiny-invariant` with the "bare module specifier":

  ```typescript
  import invariant from 'tiny-invariant';
  ```
</details>

## Additional Notes

- The blog post <https://2ality.com/2022/01/esm-specifiers.html> outlines the behavior of consuming CJS/ESM modules in great detail.
- The property `module` of `package.json` is already set, pointing to a JS file containing ESM code. While this looks like an ESM build is already configured for `tiny-invariant`, this property is not used by Node.js, see <https://stackoverflow.com/a/42817320/1700319>.