### PR TITLE
chore(build): remove some scripts in favor of `emit-module-package-file`

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,9 +61,8 @@
     "build:flow": "cp src/tiny-invariant.js.flow dist/tiny-invariant.cjs.js.flow",
     "build:typescript": "tsc ./src/tiny-invariant.ts --emitDeclarationOnly --declaration --outDir ./dist",
     "build:typescript:esm": "tsc ./src/tiny-invariant.ts --emitDeclarationOnly --declaration --outDir ./dist/esm",
-    "build:copy-esm-packagejson": "cp static/package-esm.json dist/esm/package.json",
     "build:dist": "yarn rollup --config rollup.config.js",
-    "build": "yarn build:clean && yarn build:dist && yarn build:typescript && yarn build:typescript:esm && yarn build:copy-esm-packagejson",
+    "build": "yarn build:clean && yarn build:dist && yarn build:typescript && yarn build:typescript:esm",
     "prepublishOnly": "yarn build"
   },
   "devDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -46,7 +46,20 @@ export default [
       file: 'dist/esm/tiny-invariant.js',
       format: 'esm',
     },
-    plugins: [typescript({ module: 'ESNext' })],
+    plugins: [
+      typescript({ module: 'ESNext' }),
+      // https://github.com/rollup/rollup/blob/69ff4181e701a0fe0026d0ba147f31bc86beffa8/build-plugins/emit-module-package-file.ts
+      {
+        generateBundle() {
+          this.emitFile({
+            fileName: 'package.json',
+            source: `{ "type": "module" }\n`,
+            type: 'asset',
+          });
+        },
+        name: 'emit-module-package-file',
+      },
+    ],
   },
   // CommonJS build
   {

--- a/static/package-esm.json
+++ b/static/package-esm.json
@@ -1,3 +1,0 @@
-{
-  "type": "module"
-}


### PR DESCRIPTION
Just a small trick that colocates generating this file with the actual build that depends~ on it.