### PR TITLE
fix(types): fixed an issue with TypeScript not being able to locate `.d.ts` with `moduleResolution: node16`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "types": "dist/tiny-invariant.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/tiny-invariant.d.ts",
       "import": "./dist/esm/tiny-invariant.js",
       "default": "./dist/tiny-invariant.cjs.js"
     }
@@ -60,9 +61,8 @@
     "build:clean": "rimraf dist",
     "build:flow": "cp src/tiny-invariant.js.flow dist/tiny-invariant.cjs.js.flow",
     "build:typescript": "tsc ./src/tiny-invariant.ts --emitDeclarationOnly --declaration --outDir ./dist",
-    "build:typescript:esm": "tsc ./src/tiny-invariant.ts --emitDeclarationOnly --declaration --outDir ./dist/esm",
     "build:dist": "yarn rollup --config rollup.config.js",
-    "build": "yarn build:clean && yarn build:dist && yarn build:typescript && yarn build:typescript:esm",
+    "build": "yarn build:clean && yarn build:dist && yarn build:typescript",
     "prepublishOnly": "yarn build"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,9 +22,11 @@
   "types": "dist/tiny-invariant.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/tiny-invariant.d.ts",
       "import": "./dist/esm/tiny-invariant.js",
-      "default": "./dist/tiny-invariant.cjs.js"
+      "default": {
+        "types": "./dist/tiny-invariant.d.ts",
+        "default": "./dist/tiny-invariant.cjs.js"
+      }
     }
   },
   "sideEffects": false,
@@ -61,8 +63,9 @@
     "build:clean": "rimraf dist",
     "build:flow": "cp src/tiny-invariant.js.flow dist/tiny-invariant.cjs.js.flow",
     "build:typescript": "tsc ./src/tiny-invariant.ts --emitDeclarationOnly --declaration --outDir ./dist",
+    "build:typescript:esm": "tsc ./src/tiny-invariant.ts --emitDeclarationOnly --declaration --outDir ./dist/esm",
     "build:dist": "yarn rollup --config rollup.config.js",
-    "build": "yarn build:clean && yarn build:dist && yarn build:typescript",
+    "build": "yarn build:clean && yarn build:dist && yarn build:typescript && yarn build:typescript:esm",
     "prepublishOnly": "yarn build"
   },
   "devDependencies": {


### PR DESCRIPTION
I've confirmed locally that it fixes the issue with such `tsconfig.json`:
```json
{
  "compilerOptions": {
    "strict": true,
    "types": [],
    "moduleResolution": "Node16"
  }
}
```

See the comment by the TS member and the author of those new module resolutions here: https://github.com/microsoft/TypeScript/pull/50890#issuecomment-1256406529