### PR TITLE
Add a `module` exports condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "types": "dist/tiny-invariant.d.ts",
   "exports": {
     ".": {
+      "module": "./dist/esm/tiny-invariant.js",
       "import": "./dist/esm/tiny-invariant.js",
       "default": "./dist/tiny-invariant.cjs.js"
     }


### PR DESCRIPTION
This would allow bundlers to "deduplicate" those:
```ts
// in pkg-a
import tinyInvariant from 'tiny-invariant'
// in pkg-b
const tinyInvariant = require('tiny-invariant')
```

Without this condition, 2 copies of `tiny-invariant` have to be loaded/bundled.

Isn't the JS ecosystem just great? 🤣 