### PR TITLE
don't omit message in production

### DIFF
--- a/src/tiny-invariant.ts
+++ b/src/tiny-invariant.ts
@@ -13,15 +13,6 @@ export default function invariant(
   if (condition) {
     return;
   }
-  // Condition not passed
-
-  // In production we strip the message but still throw
-  if (isProduction) {
-    throw new Error(prefix);
-  }
-
-  // When not in production we allow the message to pass through
-  // *This block will be removed in production builds*
 
   const provided: string | undefined = typeof message === 'function' ? message() : message;
 


### PR DESCRIPTION
It was very unexpected that the production version of the library is different than the development version.

It's very helpful to have the exact invariant message in the exception for easy debugging through tools like sentry.

Curious your thoughts here! I can fix up the tests if you are open to making this change.
