### PR TITLE
clarify message functionality in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ invariant(falsyValue, 'This will throw!');
 // Error('Invariant violation: This will throw!');
 ```
 
+## Why `tiny-invariant`?
+`tiny-invariant` is a *tiny*, widely-supported, zero-dependency alternative to [`invariant`](https://www.npmjs.com/package/invariant). See [below](#Dropping your message for kb savings!) for details on just how compact it can get.
+
 ## Error Messages
 
 `tiny-invariant` allows you to pass a single string message. With [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) there is really no need for a custom message formatter to be built into the library. If you need a multi part message you can just do this:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ invariant(falsyValue, 'This will throw!');
 // Error('Invariant violation: This will throw!');
 ```
 
+## Error Messages
+
+`tiny-invariant` allows you to pass a single string message. With [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) there is really no need for a custom message formatter to be built into the library. If you need a multi part message you can just do this:
+
+```js
+invariant(condition, `Hello, ${name} - how are you today?`);
+```
+
 You can also provide a function to generate your message, for when your message is expensive to create
 
 ```js
@@ -29,13 +37,7 @@ import invariant from 'tiny-invariant';
 invariant(value, () => getExpensiveMessage());
 ```
 
-## Why `tiny-invariant`?
-
-The [`library: invariant`](https://www.npmjs.com/package/invariant) supports passing in arguments to the `invariant` function in a sprintf style `(condition, format, a, b, c, d, e, f)`. It has internal logic to execute the sprintf substitutions. The sprintf logic is not removed in production builds. `tiny-invariant` has dropped all of the sprintf logic. `tiny-invariant` allows you to pass a single string message. With [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) there is really no need for a custom message formatter to be built into the library. If you need a multi part message you can just do this:
-
-```js
-invariant(condition, `Hello, ${name} - how are you today?`);
-```
+When `process.env.NODE_ENV` is set to `production`, the message will be replaced with the generic message `Invariant failed`.
 
 ## Type narrowing
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ invariant(falsyValue, 'This will throw!');
 ```
 
 ## Why `tiny-invariant`?
-`tiny-invariant` is a *tiny*, widely-supported, zero-dependency alternative to [`invariant`](https://www.npmjs.com/package/invariant). See [below](#Dropping your message for kb savings!) for details on just how compact it can get.
+`tiny-invariant` is a *tiny*, widely-supported, zero-dependency alternative to [`invariant`](https://www.npmjs.com/package/invariant). See below for details on just how compact it can get.
+
+`tiny-invariant` - when every byte counts!
 
 ## Error Messages
 


### PR DESCRIPTION
README.md changes:
- removes reference to sprintf-style message functionality that is no longer included
- renames section `Why tiny-invariant?` to `Error Messages`
- adds sentence about the message being stripped in production environments

I hope this is helpful, and thank you for such a useful, efficient package!